### PR TITLE
fix: duplicate tailwind styles with ui and nextjs app

### DIFF
--- a/apps/nextjs/src/app/layout.tsx
+++ b/apps/nextjs/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import "@acme/ui/styles.css";
 import "../styles/globals.css";
 import { Inter } from "next/font/google";
 import LocalFont from "next/font/local";

--- a/apps/nextjs/tailwind.config.ts
+++ b/apps/nextjs/tailwind.config.ts
@@ -5,7 +5,7 @@ import baseConfig from "@acme/tailwind-config";
 export default {
   content: [
     ...baseConfig.content,
-    "../../packages/ui/src/**/*.{js,jsx,ts,tsx,mdx}",
+    "../../packages/ui/src/**/*.{ts,tsx}",
   ],
   presets: [baseConfig],
 } satisfies Config;

--- a/apps/nextjs/tailwind.config.ts
+++ b/apps/nextjs/tailwind.config.ts
@@ -3,6 +3,9 @@ import type { Config } from "tailwindcss";
 import baseConfig from "@acme/tailwind-config";
 
 export default {
-  content: baseConfig.content,
+  content: [
+    ...baseConfig.content,
+    "../../packages/ui/src/**/*.{js,jsx,ts,tsx,mdx}",
+  ],
   presets: [baseConfig],
 } satisfies Config;

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -3,11 +3,7 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 
 export default {
   darkMode: ["class"],
-  content: [
-    "src/**/*.{ts,tsx}",
-    "components/**/*.{ts,tsx}",
-    "../../packages/ui/src/*.{ts,tsx}",
-  ],
+  content: ["src/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
   theme: {
     container: {
       center: true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,6 @@
   },
   "exports": {
     "./package.json": "./package.json",
-    "./styles.css": "./dist/index.css",
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,1 @@
-import "./styles.css";
-
 export { cn } from "./utils/cn";

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,3 +1,4 @@
+/* This is used to gain access to tailwind classes in the package files, but is not used for compilation purposes */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,4 +1,4 @@
-/* This file is not used for any compilation purpose, it is only used for tailwind classes autocomplete in the source files */
+/* This file is not used for any compilation purpose, it is only used for Tailwind Intellisense & Autocompletion in the source files */
 import type { Config } from "tailwindcss";
 
 import baseConfig from "@acme/tailwind-config";

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,3 +1,4 @@
+/* This file is not used for any compilation purpose, it is only used for tailwind classes autocomplete in the source files */
 import type { Config } from "tailwindcss";
 
 import baseConfig from "@acme/tailwind-config";

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -59,7 +59,6 @@ export default defineConfig((opts) => {
         ) as PackageJson;
         pkgJson.exports = {
           "./package.json": "./package.json",
-          "./styles.css": "./dist/index.css",
           ".": {
             import: "./dist/index.mjs",
             types: "./dist/index.d.ts",


### PR DESCRIPTION
**What this PR solves:**

Previously, the ui library did its own compilation for the styles, this lead to duplicate styles because the nextjs app is also doing it's own tailwind compilation so for example, `@tailwind base;` in both the UI library and nextjs app leads to two CSS resets in the application's styling as well as the cases where the same tailwind class is used for both the application and the UI library. If a button has the `text-blue-500` class for example and somewhere in the nextjs application you're using the same class, it would lead to two stylesheets with two `text-blue-500` classes.

**How this PR goes about solving the problem:**

instead of the UI library doing it's own styles compilation and spitting that out to the dist file, we let the nextjs application scan the UI package source files and compile the classes used there in the application's styles file. This leads to a single CSS stylesheet with no duplicate classes anywhere.

**How this was tested:**

Previously, the issue was that without the UI compiling it's own CSS, the styles would show up in dev but not in the `start` script aka in production. The change in this PR is tested against the `start` script of the nextjs app to make sure it is working as expected.