### PR TITLE
esbuildOptions for "use client" ui types bundling and id with timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ yarn-error.log*
 
 # turbo
 .turbo
+
+# intelliJ and WebStorm
+.idea/
+.idea/acme-corp.iml
+.idea/modules.xml
+.idea/workspace.xml
+./vcs.xml

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     "with-env": "dotenv -e ../../.env.local --"
   },
   "dependencies": {
+    "@paralleldrive/cuid2": "^2.2.1",
     "@planetscale/database": "^1.7.0",
     "kysely": "^0.25.0",
     "kysely-planetscale": "^1.3.0",

--- a/packages/db/prisma/postgenerate.ts
+++ b/packages/db/prisma/postgenerate.ts
@@ -16,7 +16,8 @@ const outputFile = path.join(process.cwd(), "index.ts");
 
 import { Kysely } from "kysely";
 import { PlanetScaleDialect } from "kysely-planetscale";
-import { customAlphabet } from "nanoid";
+// import { customAlphabet } from "nanoid";
+import { createId } from '@paralleldrive/cuid2';
 
 ${dbTypes}
 
@@ -28,7 +29,11 @@ export const db = new Kysely<DB>({
 
 // Use custom alphabet without special chars for less chaotic, copy-able URLs
 // Will not collide for a long long time: https://zelark.github.io/nano-id-cc/
-export const genId = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 16);
+// export const genId = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 16);
+
+// Use cuid to generate id with timestamp, use prefix_ + cuid2
+export const genId = createId;
+
 `;
 
   await writeFile(outputFile, output, "utf-8");

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -50,7 +50,7 @@ export default defineConfig((opts) => {
     },
     {
       ...common,
-      entry: client,
+      entry: ["./src/index.ts", ...client],
       esbuildOptions: (opts) => {
         opts.banner = {
           js: '"use client";',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@paralleldrive/cuid2':
+        specifier: ^2.2.1
+        version: 2.2.1
       '@planetscale/database':
         specifier: ^1.7.0
         version: 1.7.0
@@ -4056,6 +4059,11 @@ packages:
     hasBin: true
     dev: false
 
+  /@noble/hashes@1.3.1:
+    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
+    engines: {node: '>= 16'}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -4132,6 +4140,12 @@ packages:
     resolution: {integrity: sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA==}
     engines: {node: '>=14'}
     dev: true
+
+  /@paralleldrive/cuid2@2.2.1:
+    resolution: {integrity: sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==}
+    dependencies:
+      '@noble/hashes': 1.3.1
+    dev: false
 
   /@peculiar/asn1-schema@2.3.6:
     resolution: {integrity: sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==}


### PR DESCRIPTION
1. in `packages/ui/tsup.config.ts` 
change `entry: client` to `entry: ["./src/index.ts", ...client]` to bundle types for UI files with "use client" banner. Otherwise UIs like `avatar` can get rendered on browser but will always throw errors in IDE.

2. suggest using cuid in `postgenerate.ts` to generate ID with timestamps

3. ignore webstorm config files.