### PR TITLE
Add / link to the logo

### DIFF
--- a/apps/nextjs/src/app/(marketing)/layout.tsx
+++ b/apps/nextjs/src/app/(marketing)/layout.tsx
@@ -16,10 +16,13 @@ export default function MarketingLayout(props: { children: ReactNode }) {
     <div className="flex min-h-screen flex-col">
       <nav className="container z-50 flex h-16 items-center border-b bg-background">
         <div className="mr-8 hidden items-center md:flex">
-          <Icons.Logo className="mr-2 h-6 w-6" />
-          <span className="text-lg font-bold tracking-tight">
-            {siteConfig.name}
-          </span>
+          <Link
+            href="/"
+            className="text-lg font-bold tracking-tight"
+          >
+            <Icons.Logo className="mr-2 h-6 w-6" />
+            <span>{siteConfig.name}</span>
+          </Link>
         </div>
         <MobileDropdown />
         <MainNav />


### PR DESCRIPTION
This PR adds a link to the homepage on the logo in the header. Previously, the logo was not clickable, and users couldn't navigate back to the homepage easily. With this change, we have wrapped the logo and site name with a Link component, pointing to the homepage ("/"). Now, users can click on the logo to go back to the home page, providing a more intuitive navigation experience. The old code has been updated to the new code with the necessary changes.

Please review and merge this PR once approved.